### PR TITLE
Fix login response

### DIFF
--- a/src/controllers/userControllers.ts
+++ b/src/controllers/userControllers.ts
@@ -4,9 +4,10 @@ import { UserAttributes } from "../interfaces/userInterface";
 async function loginController(req: Request, res: Response) {
   try {
     const { email, password } = req.body;
-    const token = await loginUserService(email, password);
-    if (token) {
-      res.status(200).json({ token });
+    const loginResult = await loginUserService(email, password);
+    if (loginResult) {
+      const { token, user } = loginResult;
+      res.status(200).json({ token, user });
     } else {
       res.status(401).json({ error: "Invalid credentials" });
     }


### PR DESCRIPTION
## Summary
- fix login controller to return both token and user info

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'bcrypt', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6847aacf07088322aed50bb07454417b