### PR TITLE
Add Jest test for /test endpoint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts']
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Descripción de tu proyecto",
   "scripts": {
     "start": "nodemon dist/app.js",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "jest"
   },
   "dependencies": {
     "@types/bcrypt": "^5.0.0",
@@ -41,6 +42,11 @@
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.7",
     "nodemon": "^3.0.1",
-    "sequelize-cli": "^6.6.1"
+    "sequelize-cli": "^6.6.1",
+    "jest": "^29.6.1",
+    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.3",
+    "supertest": "^6.3.3",
+    "@types/supertest": "^2.0.12"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -86,9 +86,11 @@ app.use("/lotery", lotteryRoute)
 
 orderSocket(io);
 
-server.listen(PORT, () => {
-  console.log("dirname", __dirname);
-  console.log(`Servidor escuchando en el puerto ${PORT}`);
-});
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log("dirname", __dirname);
+    console.log(`Servidor escuchando en el puerto ${PORT}`);
+  });
+}
 
-export { io };
+export { io, app, server };

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import { app } from '../src/app';
+
+describe('GET /test', () => {
+  it('should return success message', async () => {
+    const response = await request(app).get('/test');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ message: '¡La prueba fue exitosa!' });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,6 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true
-  }
+  },
+  "exclude": ["tests"]
 }


### PR DESCRIPTION
## Summary
- add jest configuration and testing dependencies
- export Express app for testing
- add simple endpoint test for `/test`
- exclude tests from TypeScript build

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847ad7dc2288322ad04753720f0be39