### PR TITLE
Add endpoint tests

### DIFF
--- a/tests/order.test.ts
+++ b/tests/order.test.ts
@@ -1,0 +1,33 @@
+import request from 'supertest';
+import { app, io } from '../src/app';
+import * as orderService from '../src/services/orderService';
+import * as orderProductService from '../src/services/orderProductService';
+
+jest.mock('../src/services/orderService');
+jest.mock('../src/services/orderProductService');
+
+describe('Order endpoints', () => {
+  beforeEach(() => {
+    jest.spyOn(io, 'emit').mockImplementation(() => false);
+  });
+
+  describe('POST /order/new', () => {
+    it('creates a new order', async () => {
+      (orderService.createOrderService as jest.Mock).mockResolvedValue({ id: 1 });
+      (orderProductService.createOrderProductService as jest.Mock).mockResolvedValue(undefined);
+      (orderProductService.getAllOrderProductsByIdService as jest.Mock).mockResolvedValue([]);
+
+      const body = {
+        deliveryMethod: 'delivery',
+        userInfo: { name: 'John', phone: '123', address: 'Street' },
+        simplifiedCartItems: [{ productId: 1, quantity: 2 }],
+        totalAmount: 100,
+        totalCostPrice: 80
+      };
+
+      const response = await request(app).post('/order/new').send(body);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ status: 'OK' });
+    });
+  });
+});

--- a/tests/product.test.ts
+++ b/tests/product.test.ts
@@ -1,0 +1,34 @@
+import request from 'supertest';
+import { app } from '../src/app';
+import * as productService from '../src/services/productService';
+
+jest.mock('../src/services/productService');
+
+describe('Product endpoints', () => {
+  describe('GET /product/all', () => {
+    it('returns list of products', async () => {
+      const products = [{ id: 1, name: 'Prod1' }];
+      (productService.getAllProductsService as jest.Mock).mockResolvedValue(products);
+      const response = await request(app).get('/product/all');
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(products);
+    });
+  });
+
+  describe('GET /product/:id', () => {
+    it('returns a product when found', async () => {
+      const product = { id: 1, name: 'Prod1' };
+      (productService.getProductByIdService as jest.Mock).mockResolvedValue(product);
+      const response = await request(app).get('/product/1');
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(product);
+    });
+
+    it('returns 404 when not found', async () => {
+      (productService.getProductByIdService as jest.Mock).mockResolvedValue(null);
+      const response = await request(app).get('/product/999');
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ error: 'Product not found' });
+    });
+  });
+});

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -1,0 +1,45 @@
+import request from 'supertest';
+import { app } from '../src/app';
+import * as userService from '../src/services/userService';
+
+jest.mock('../src/services/userService');
+
+describe('User endpoints', () => {
+  describe('POST /user/login', () => {
+    it('returns token for valid credentials', async () => {
+      (userService.loginUserService as jest.Mock).mockResolvedValue('mock-token');
+      const response = await request(app)
+        .post('/user/login')
+        .send({ email: 'test@example.com', password: 'password' });
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ token: 'mock-token' });
+    });
+
+    it('returns 401 for invalid credentials', async () => {
+      (userService.loginUserService as jest.Mock).mockResolvedValue(null);
+      const response = await request(app)
+        .post('/user/login')
+        .send({ email: 'wrong@example.com', password: 'wrong' });
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'Invalid credentials' });
+    });
+  });
+
+  describe('POST /user/register', () => {
+    it('creates a new user', async () => {
+      const newUser = {
+        id: 1,
+        name: 'Test',
+        email: 'test@example.com',
+        password: 'hashed',
+        roleId: 2,
+      };
+      (userService.registerUserService as jest.Mock).mockResolvedValue(newUser);
+      const response = await request(app)
+        .post('/user/register')
+        .send({ name: 'Test', email: 'test@example.com', password: 'password' });
+      expect(response.status).toBe(201);
+      expect(response.body).toEqual(newUser);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for user login and registration
- add tests for product retrieval
- test order creation endpoint with mocks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b2bd1a488322aec6c95491de78ba