### PR TITLE
Fix import for getCurrentLottery

### DIFF
--- a/src/services/lotteryService.ts
+++ b/src/services/lotteryService.ts
@@ -1,5 +1,5 @@
 
-import { createLottery } from "../repositories/lotteryRepository";
+import { createLottery, getCurrentLottery } from "../repositories/lotteryRepository";
 import { createLotteryProducts } from "../repositories/lotteryProductsRepository";
 import { getProductsCost } from "../repositories/productRepository"; 
 


### PR DESCRIPTION
## Summary
- fix missing import from lottery repository

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b615dc5c8322afea1000f777467c